### PR TITLE
Fixed setting tags for Wikidot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.pass
 .project
 */.coverage
+__pycache__
+*.pyc

--- a/pyscp/wikidot.py
+++ b/pyscp/wikidot.py
@@ -260,7 +260,7 @@ class Page(pyscp.core.Page):
 
     def set_tags(self, tags):
         """Replace the tags of the page."""
-        res = self._action('saveTags', tags=''.join(tags))
+        res = self._action('saveTags', tags=' '.join(tags))
         self._flush('history', '_pdata')
         return res
 


### PR DESCRIPTION
set_tags will take a list of strings and join them with space, so ["test1", "test2"] becomes "test1 test2"